### PR TITLE
Make GitHub not detect *.f as Forth.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.f linguist-language=Text
+


### PR DESCRIPTION
Hello,

Please merge this, if you'd like GitHub to not detect the `.f` file as being written in Forth.

The misdetected files are shown here:
https://github.com/srobo/inventory/search?l=forth

Thanks!